### PR TITLE
Enqueue wc-cart-fragments scripts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -223,6 +223,8 @@ class WeDevs_Dokan_Theme {
         wp_enqueue_script( 'flexslider', $template_directory . '/assets/js/jquery.flexslider-min.js', array( 'jquery' ) );
 
         wp_enqueue_script( 'dokan-theme-scripts', $template_directory . '/assets/js/script.js', false, null, true );
+
+        wp_enqueue_script('wc-cart-fragments');
     }
 
     /**

--- a/functions.php
+++ b/functions.php
@@ -224,7 +224,7 @@ class WeDevs_Dokan_Theme {
 
         wp_enqueue_script( 'dokan-theme-scripts', $template_directory . '/assets/js/script.js', false, null, true );
 
-        wp_enqueue_script('wc-cart-fragments');
+        wp_enqueue_script( 'wc-cart-fragments' );
     }
 
     /**


### PR DESCRIPTION
As per the [Woocommerce explanation](https://developer.woocommerce.com/2023/06/16/best-practices-for-the-use-of-the-cart-fragments-api/), they have removed wc-cart-fragments to increase the performance. Please see https://stackoverflow.com/a/76505287/2286634 for more details. 

Closes #42 